### PR TITLE
Dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elsikora/x-captcha-react",
-	"version": "2.0.1-dev.2",
+	"version": "2.0.2-dev.1",
 	"description": "React components for X-Captcha service",
 	"keywords": [
 		"captcha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elsikora/x-captcha-react",
-	"version": "2.0.2-dev.1",
+	"version": "2.0.2-dev.2",
 	"description": "React components for X-Captcha service",
 	"keywords": [
 		"captcha",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix stale callback references in CaptchaWidget component

- Use useRef to store latest onLoad callback

- Remove onLoad from useCallback dependency array

- Update package version to 2.0.2-dev.2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["onLoad prop"] --> B["useRef storage"]
  B --> C["useEffect updates ref"]
  C --> D["loadChallenge uses ref.current"]
  D --> E["Prevents stale callbacks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Version bump to 2.0.2-dev.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Update version from 2.0.1-dev.2 to 2.0.2-dev.2


</details>


  </td>
  <td><a href="https://github.com/ElsiKora/X-Captcha-React/pull/36/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaptchaWidget.tsx</strong><dd><code>Fix stale callback references using useRef</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/presentation/components/CaptchaWidget.tsx

<ul><li>Add useRef import and create onLoadReference ref<br> <li> Add useEffect to update ref with latest onLoad callback<br> <li> Replace direct onLoad call with ref.current callback<br> <li> Remove onLoad from loadChallenge dependency array</ul>


</details>


  </td>
  <td><a href="https://github.com/ElsiKora/X-Captcha-React/pull/36/files#diff-345eaf9f5de70fcbbbc7f0114818030385f46d38da956f97ad96790b65428723">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

